### PR TITLE
Version bump so the main puppet repo sees @kwolf's change

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name 'backstop-jmeter'
-version '1.1.0'
+version '1.1.1'
 source 'git://github.com/backstop/puppet-jmeter.git'
 author 'Backstop Solutions'
 license 'Apache 2.0'


### PR DESCRIPTION
Reinstalling jslave04, it's still trying to grab stuff from ibiblio. Think it needs to be version bumped and the ref updated in the Puppetfile.lock.